### PR TITLE
ci: add milestone-based issue linking workflow

### DIFF
--- a/.github/workflows/link-issues-by-milestone.yml
+++ b/.github/workflows/link-issues-by-milestone.yml
@@ -1,0 +1,16 @@
+name: Link Issue to Milestone Parent
+
+on:
+  issues:
+    types: [milestoned]
+
+jobs:
+  link-issue:
+    if: github.event.issue.milestone != null
+    uses: AllenNeuralDynamics/.github/.github/workflows/util-link-issues-by-milestone.yml@main
+    with:
+      issue-number: ${{ github.event.issue.number }}
+      issue-id: ${{ github.event.issue.id }}
+      milestone-description: ${{ github.event.issue.milestone.description }}
+    secrets:
+      service-token: ${{ secrets.SERVICE_TOKEN }}


### PR DESCRIPTION

Adds `link-issues-by-milestone.yml` which calls the shared reusable workflow from `AllenNeuralDynamics/.github` to automatically link milestoned issues as sub-issues of their parent roadmap item in `aind-scientific-computing`.
